### PR TITLE
Update service.sh

### DIFF
--- a/bin/service.sh
+++ b/bin/service.sh
@@ -4,6 +4,6 @@ docker build -t log-service:latest .
 
 docker service rm log-service || true
 docker service create --name log-service \
-  -m type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
+  --mount type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock \
   --network amp-build \
   log-service:latest


### PR DESCRIPTION
The `-m` flag is no longer available with the GA release of Docker v1.12. This PR updates it to `--mount`.
